### PR TITLE
Url encode basic auth while reading avro schema in Kafka Connector

### DIFF
--- a/src/Processors/Formats/Impl/AvroRowInputFormat.cpp
+++ b/src/Processors/Formats/Impl/AvroRowInputFormat.cpp
@@ -739,7 +739,15 @@ private:
                 if (!url.getUserInfo().empty()) {
                     Poco::Net::HTTPCredentials httpCredentials;
                     httpCredentials.fromUserInfo(url.getUserInfo());
-                    Poco::Net::HTTPBasicCredentials httpBasicCredentials(httpCredentials.getUsername(), httpCredentials.getPassword());
+                    Poco::Net::HTTPBasicCredentials httpBasicCredentials;
+
+                    if (!httpCredentials.getPassword().empty()) {
+                        httpBasicCredentials.setUsername(httpCredentials.getUsername());
+                        httpBasicCredentials.setPassword(httpCredentials.getPassword());
+                    }
+                    else {
+                        httpBasicCredentials.setUsername(httpCredentials.getUsername());
+                    }
 
                     httpBasicCredentials.authenticate(request);
                 }

--- a/src/Processors/Formats/Impl/AvroRowInputFormat.cpp
+++ b/src/Processors/Formats/Impl/AvroRowInputFormat.cpp
@@ -737,26 +737,26 @@ private:
                 request.setHost(url.getHost());
 
                 if (!url.getUserInfo().empty()) {
-                    Poco::Net::HTTPCredentials httpCredentials;
-                    Poco::Net::HTTPBasicCredentials httpBasicCredentials;
+                    Poco::Net::HTTPCredentials http_credentials;
+                    Poco::Net::HTTPBasicCredentials http_basic_credentials;
                     std::string decoded_username;
                     std::string decoded_password;
 
-                    httpCredentials.fromUserInfo(url.getUserInfo());
+                    http_credentials.fromUserInfo(url.getUserInfo());
 
-                    if (!httpCredentials.getPassword().empty()) {
-                        Poco::URI::decode(httpCredentials.getUsername(), decoded_username);
-                        Poco::URI::decode(httpCredentials.getPassword(), decoded_password);
+                    if (!http_credentials.getPassword().empty()) {
+                        Poco::URI::decode(http_credentials.getUsername(), decoded_username);
+                        Poco::URI::decode(http_credentials.getPassword(), decoded_password);
 
-                        httpBasicCredentials.setUsername(decoded_username);
-                        httpBasicCredentials.setPassword(decoded_password);
+                        http_basic_credentials.setUsername(decoded_username);
+                        http_basic_credentials.setPassword(decoded_password);
                     }
                     else {
-                        Poco::URI::decode(httpCredentials.getUsername(), decoded_username);
-                        httpBasicCredentials.setUsername(decoded_username);
+                        Poco::URI::decode(http_credentials.getUsername(), decoded_username);
+                        http_basic_credentials.setUsername(decoded_username);
                     }
 
-                    httpBasicCredentials.authenticate(request);
+                    http_basic_credentials.authenticate(request);
                 }
 
                 auto session = makePooledHTTPSession(url, timeouts, 1);

--- a/src/Processors/Formats/Impl/AvroRowInputFormat.cpp
+++ b/src/Processors/Formats/Impl/AvroRowInputFormat.cpp
@@ -738,15 +738,22 @@ private:
 
                 if (!url.getUserInfo().empty()) {
                     Poco::Net::HTTPCredentials httpCredentials;
-                    httpCredentials.fromUserInfo(url.getUserInfo());
                     Poco::Net::HTTPBasicCredentials httpBasicCredentials;
+                    std::string decoded_username;
+                    std::string decoded_password;
+
+                    httpCredentials.fromUserInfo(url.getUserInfo());
 
                     if (!httpCredentials.getPassword().empty()) {
-                        httpBasicCredentials.setUsername(httpCredentials.getUsername());
-                        httpBasicCredentials.setPassword(httpCredentials.getPassword());
+                        Poco::URI::decode(httpCredentials.getUsername(), decoded_username);
+                        Poco::URI::decode(httpCredentials.getPassword(), decoded_password);
+
+                        httpBasicCredentials.setUsername(decoded_username);
+                        httpBasicCredentials.setPassword(decoded_password);
                     }
                     else {
-                        httpBasicCredentials.setUsername(httpCredentials.getUsername());
+                        Poco::URI::decode(httpCredentials.getUsername(), decoded_username);
+                        httpBasicCredentials.setUsername(decoded_username);
                     }
 
                     httpBasicCredentials.authenticate(request);

--- a/src/Processors/Formats/Impl/AvroRowInputFormat.cpp
+++ b/src/Processors/Formats/Impl/AvroRowInputFormat.cpp
@@ -48,6 +48,8 @@
 #include <Poco/JSON/JSON.h>
 #include <Poco/JSON/Object.h>
 #include <Poco/JSON/Parser.h>
+#include <Poco/Net/HTTPBasicCredentials.h>
+#include <Poco/Net/HTTPCredentials.h>
 #include <Poco/Net/HTTPRequest.h>
 #include <Poco/Net/HTTPResponse.h>
 #include <Poco/URI.h>
@@ -733,6 +735,14 @@ private:
 
                 Poco::Net::HTTPRequest request(Poco::Net::HTTPRequest::HTTP_GET, url.getPathAndQuery(), Poco::Net::HTTPRequest::HTTP_1_1);
                 request.setHost(url.getHost());
+
+                if (!url.getUserInfo().empty()) {
+                    Poco::Net::HTTPCredentials httpCredentials;
+                    httpCredentials.fromUserInfo(url.getUserInfo());
+                    Poco::Net::HTTPBasicCredentials httpBasicCredentials(httpCredentials.getUsername(), httpCredentials.getPassword());
+
+                    httpBasicCredentials.authenticate(request);
+                }
 
                 auto session = makePooledHTTPSession(url, timeouts, 1);
                 std::istream * response_body{};


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/run_check.py
-->
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Kafka connector can fetch avro schema from schema registry with basic authentication using url-encoded credentials 


> Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
